### PR TITLE
Fix/android studio 5.3 beta 3 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     implementation "im.ene.toro3:toro-ext-exoplayer:${toro_version}"
     implementation "com.google.android.exoplayer:exoplayer-core:${exoplayer_version}"
     implementation "com.google.android.exoplayer:exoplayer-hls:${exoplayer_version}"
+    implementation "com.google.android.exoplayer:exoplayer-ui:${exoplayer_version}"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"

--- a/app/src/main/kotlin/com/splendidbits/peacock/view/NewsItemVideoHolder.kt
+++ b/app/src/main/kotlin/com/splendidbits/peacock/view/NewsItemVideoHolder.kt
@@ -3,7 +3,7 @@ package com.splendidbits.peacock.view
 import android.content.Context
 import android.net.Uri
 import android.view.View
-import com.google.android.exoplayer2.ui.SimpleExoPlayerView
+import com.google.android.exoplayer2.ui.PlayerView
 import com.google.android.exoplayer2.video.VideoListener
 import com.splendidbits.peacock.main.PeacockApplication
 import im.ene.toro.ToroPlayer
@@ -25,7 +25,7 @@ class NewsItemVideoHolder(itemView: View) : AbstractNewsItemHolder(itemView), To
 
     private val videoPlayerContainer = itemView.videoPlayerContainer
     private var exoPlayerHelper: ExoPlayerViewHelper? = null
-    private val videoPlayerView: SimpleExoPlayerView = itemView.videoPlayer
+    private val videoPlayerView: PlayerView = itemView.videoPlayer
     private var videoOverlayPill = itemView.videoVolumePill
     val summaryText = itemView.summary
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha08'
+        classpath 'com.android.tools.build:gradle:3.5.0-beta03'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 27 10:45:25 PDT 2019
+#Wed Jun 05 11:41:51 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-rc-2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Android Studio 5.3 (beta 3) required Gradle plugin 3.5-beta (also fixed ExoPlayer library usage)

I was not able to verify the fix: got stuck at the loading screen with `java.net.UnknownHostException: Unable to resolve host "devicestransform-stg.elasticbeanstalk.com": No address associated with hostname`

// TODO: handle offline functionality